### PR TITLE
add history@^1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.4",
+    "history": "^1.17.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-router": "^1.0.2",


### PR DESCRIPTION
npm WARN react-router@1.0.3 requires a peer of history@^1.17.0 but none was installed.